### PR TITLE
Fix mobile sidebar breaking dashboard layout

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,25 +1,46 @@
-import { useState } from "react";
-import { Outlet } from "react-router";
+import { useState, useCallback, useEffect } from "react";
+import { Outlet, useLocation } from "react-router";
 import { Sidebar } from "./Sidebar";
 import { TopBar } from "./TopBar";
 import { cn } from "../../lib/utils";
 
 export function AppLayout() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const location = useLocation();
+
+  // Close mobile sidebar on route change
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [location.pathname]);
+
+  const toggleMobile = useCallback(() => setMobileOpen((v) => !v), []);
 
   return (
     <div className="min-h-screen bg-base">
+      {/* Mobile backdrop */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/60 backdrop-blur-sm lg:hidden"
+          onClick={() => setMobileOpen(false)}
+        />
+      )}
+
       <Sidebar
         collapsed={sidebarCollapsed}
         onToggle={() => setSidebarCollapsed(!sidebarCollapsed)}
+        mobileOpen={mobileOpen}
+        onMobileClose={() => setMobileOpen(false)}
       />
       <div
         className={cn(
           "transition-all duration-300",
-          sidebarCollapsed ? "ml-16" : "ml-60"
+          // On mobile: no margin (sidebar overlays). On desktop: margin based on collapsed state.
+          "ml-0 lg:ml-60",
+          sidebarCollapsed && "lg:ml-16"
         )}
       >
-        <TopBar />
+        <TopBar onMobileMenuToggle={toggleMobile} />
         <main className="min-h-[calc(100vh-4rem)]">
           <Outlet />
         </main>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -13,20 +13,28 @@ const NAV_ITEMS = [
 interface SidebarProps {
   collapsed: boolean;
   onToggle: () => void;
+  mobileOpen?: boolean;
+  onMobileClose?: () => void;
 }
 
-export function Sidebar({ collapsed, onToggle }: SidebarProps) {
+export function Sidebar({ collapsed, onToggle, mobileOpen = false }: SidebarProps) {
   return (
     <aside
       className={cn(
         "fixed left-0 top-0 z-40 h-screen flex flex-col bg-surface border-r border-border-subtle transition-all duration-300",
-        collapsed ? "w-16" : "w-60"
+        // Mobile: slide in/out, always full width when open
+        mobileOpen ? "translate-x-0" : "-translate-x-full",
+        "lg:translate-x-0",
+        // Desktop: respect collapsed state. Mobile: always w-60 when open.
+        "w-60",
+        collapsed && "lg:w-16"
       )}
     >
       {/* Logo */}
       <div className="flex items-center h-16 px-4 border-b border-border-subtle">
         <span className="font-display font-bold text-accent text-xl tracking-tight">
-          {collapsed ? "JJ" : "JJSMade"}
+          <span className={cn("hidden", collapsed && "lg:inline")}>JJ</span>
+          <span className={cn(collapsed && "lg:hidden")}>JJSMade</span>
         </span>
       </div>
 
@@ -47,7 +55,8 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
             }
           >
             <Icon size={20} className="shrink-0" />
-            {!collapsed && <span>{label}</span>}
+            {/* Always show on mobile; on desktop, hide when collapsed */}
+            <span className={cn(collapsed && "lg:hidden")}>{label}</span>
           </NavLink>
         ))}
       </nav>
@@ -55,7 +64,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
       {/* Collapse button */}
       <button
         onClick={onToggle}
-        className="flex items-center justify-center h-12 border-t border-border-subtle text-secondary hover:text-primary hover:bg-hover transition-colors"
+        className="hidden lg:flex items-center justify-center h-12 border-t border-border-subtle text-secondary hover:text-primary hover:bg-hover transition-colors"
       >
         {collapsed ? <ChevronRight size={18} /> : <ChevronLeft size={18} />}
       </button>

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,5 +1,5 @@
 import { useLocation, useNavigate } from "react-router";
-import { Plus } from "lucide-react";
+import { Plus, Menu } from "lucide-react";
 import { Button } from "../ui/Button";
 
 const PAGE_TITLES: Record<string, string> = {
@@ -11,7 +11,11 @@ const PAGE_TITLES: Record<string, string> = {
   "/settings": "Settings",
 };
 
-export function TopBar() {
+interface TopBarProps {
+  onMobileMenuToggle?: () => void;
+}
+
+export function TopBar({ onMobileMenuToggle }: TopBarProps) {
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -22,8 +26,16 @@ export function TopBar() {
   else if (location.pathname.match(/^\/sellers\/[^/]+$/)) title = "Seller Details";
 
   return (
-    <header className="sticky top-0 z-30 flex items-center justify-between h-16 px-6 bg-surface/80 backdrop-blur-md border-b border-border-subtle">
-      <h1 className="font-display font-bold text-xl text-primary">{title}</h1>
+    <header className="sticky top-0 z-20 flex items-center justify-between h-16 px-4 sm:px-6 bg-surface/80 backdrop-blur-md border-b border-border-subtle">
+      <div className="flex items-center gap-3">
+        <button
+          onClick={onMobileMenuToggle}
+          className="lg:hidden p-2 -ml-2 text-secondary hover:text-primary hover:bg-hover rounded-lg transition-colors"
+        >
+          <Menu size={20} />
+        </button>
+        <h1 className="font-display font-bold text-xl text-primary">{title}</h1>
+      </div>
       <div className="flex items-center gap-3">
         <Button onClick={() => navigate("/orders/new")} size="sm">
           <Plus size={16} />


### PR DESCRIPTION
## Summary
- Sidebar now slides in as an overlay on mobile instead of pushing content with `ml-60`, which was cramping dashboard cards
- Added a dark backdrop overlay when mobile sidebar is open
- Added hamburger menu button to TopBar (visible only on mobile)
- Sidebar auto-closes on route navigation

## Test plan
- [x] Open app on mobile viewport (< 1024px) — sidebar should be hidden, content uses full width
- [x] Tap hamburger icon — sidebar slides in with backdrop, dashboard cards are not affected
- [x] Tap a nav link — sidebar closes and navigates
- [x] Tap backdrop — sidebar closes
- [x] On desktop (>= 1024px) — sidebar collapse/expand still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mobile sidebar toggle menu button in the top bar for improved mobile navigation
  * Implemented mobile backdrop overlay to dismiss the sidebar with a single tap
  * Enhanced responsive layout with automatic sidebar closure during page navigation
  * Improved mobile and desktop experience with refined layout spacing and visibility controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->