### PR TITLE
Add QC photo deletion in detail carousel with persisted cleanup

### DIFF
--- a/convex/items.ts
+++ b/convex/items.ts
@@ -1,6 +1,7 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 import { computeDerivedFields } from "./helpers";
+import { deleteUnreferencedQcPhotos } from "./qcPhotoCleanup";
 
 const CLOTHES_SIZES = new Set(["S", "M", "L", "XL"]);
 
@@ -194,6 +195,15 @@ export const update = mutation({
     const { id, ...updates } = args;
     const existing = await ctx.db.get(id);
     if (!existing) throw new Error("Item not found");
+    const hasQcPhotoIdsUpdate = Object.prototype.hasOwnProperty.call(
+      updates,
+      "qcPhotoIds"
+    );
+    const updatedQcPhotoIds = hasQcPhotoIdsUpdate ? updates.qcPhotoIds ?? [] : [];
+    const updatedQcPhotoIdSet = new Set(updatedQcPhotoIds);
+    const removedQcPhotoIds = hasQcPhotoIdsUpdate
+      ? (existing.qcPhotoIds ?? []).filter((photoId) => !updatedQcPhotoIdSet.has(photoId))
+      : [];
 
     const hasTrackingNumberUpdate = Object.prototype.hasOwnProperty.call(
       updates,
@@ -271,6 +281,8 @@ export const update = mutation({
       soldDate,
       updatedAt: now,
     });
+
+    await deleteUnreferencedQcPhotos(ctx, removedQcPhotoIds, { table: "items", id });
   },
 });
 
@@ -311,7 +323,14 @@ export const updateQcStatus = mutation({
 export const remove = mutation({
   args: { id: v.id("items") },
   handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.id);
+    if (!existing) return;
+    const removedQcPhotoIds = existing.qcPhotoIds ?? [];
     await ctx.db.delete(args.id);
+    await deleteUnreferencedQcPhotos(ctx, removedQcPhotoIds, {
+      table: "items",
+      id: args.id,
+    });
   },
 });
 

--- a/convex/personalItems.ts
+++ b/convex/personalItems.ts
@@ -1,6 +1,7 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 import { computeDerivedFields } from "./helpers";
+import { deleteUnreferencedQcPhotos } from "./qcPhotoCleanup";
 
 const CLOTHES_SIZES = new Set(["S", "M", "L", "XL"]);
 
@@ -173,6 +174,15 @@ export const update = mutation({
     const { id, ...updates } = args;
     const existing = await ctx.db.get(id);
     if (!existing) throw new Error("Personal item not found");
+    const hasQcPhotoIdsUpdate = Object.prototype.hasOwnProperty.call(
+      updates,
+      "qcPhotoIds"
+    );
+    const updatedQcPhotoIds = hasQcPhotoIdsUpdate ? updates.qcPhotoIds ?? [] : [];
+    const updatedQcPhotoIdSet = new Set(updatedQcPhotoIds);
+    const removedQcPhotoIds = hasQcPhotoIdsUpdate
+      ? (existing.qcPhotoIds ?? []).filter((photoId) => !updatedQcPhotoIdSet.has(photoId))
+      : [];
 
     const hasTrackingNumberUpdate = Object.prototype.hasOwnProperty.call(
       updates,
@@ -239,6 +249,11 @@ export const update = mutation({
       qcServiceFeePHP: derived.qcServiceFeePHP,
       updatedAt: Date.now(),
     });
+
+    await deleteUnreferencedQcPhotos(ctx, removedQcPhotoIds, {
+      table: "personalItems",
+      id,
+    });
   },
 });
 
@@ -257,7 +272,14 @@ export const updateStatus = mutation({
 export const remove = mutation({
   args: { id: v.id("personalItems") },
   handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.id);
+    if (!existing) return;
+    const removedQcPhotoIds = existing.qcPhotoIds ?? [];
     await ctx.db.delete(args.id);
+    await deleteUnreferencedQcPhotos(ctx, removedQcPhotoIds, {
+      table: "personalItems",
+      id: args.id,
+    });
   },
 });
 

--- a/convex/qcPhotoCleanup.ts
+++ b/convex/qcPhotoCleanup.ts
@@ -1,0 +1,42 @@
+import type { Id } from "./_generated/dataModel";
+import type { MutationCtx } from "./_generated/server";
+
+type ExcludedReference =
+  | { table: "items"; id: Id<"items"> }
+  | { table: "personalItems"; id: Id<"personalItems"> };
+
+export async function deleteUnreferencedQcPhotos(
+  ctx: MutationCtx,
+  candidateIds: Id<"_storage">[],
+  excluded?: ExcludedReference
+) {
+  if (candidateIds.length === 0) return;
+
+  const uniqueIds = Array.from(new Set(candidateIds));
+  const [items, personalItems] = await Promise.all([
+    ctx.db.query("items").collect(),
+    ctx.db.query("personalItems").collect(),
+  ]);
+
+  for (const storageId of uniqueIds) {
+    const usedByItem = items.some((item) => {
+      if (excluded?.table === "items" && item._id === excluded.id) {
+        return false;
+      }
+      return (item.qcPhotoIds ?? []).includes(storageId);
+    });
+
+    if (usedByItem) continue;
+
+    const usedByPersonalItem = personalItems.some((item) => {
+      if (excluded?.table === "personalItems" && item._id === excluded.id) {
+        return false;
+      }
+      return (item.qcPhotoIds ?? []).includes(storageId);
+    });
+
+    if (!usedByPersonalItem) {
+      await ctx.storage.delete(storageId);
+    }
+  }
+}

--- a/src/components/items/ItemForm.tsx
+++ b/src/components/items/ItemForm.tsx
@@ -15,6 +15,7 @@ import { ImageUpload } from "../ui/ImageUpload";
 import { LiveProfitCalculator } from "./LiveProfitCalculator";
 import { MarkupIndicator } from "./MarkupIndicator";
 import { PriceCalculator } from "./PriceCalculator";
+import { QcPhotoGallery } from "./QcPhotoGallery";
 import {
   ALL_STATUSES,
   ALL_QC_STATUSES,
@@ -178,6 +179,7 @@ export function ItemForm({ existingItem, onSuccess }: ItemFormProps) {
   const showQcSection = QC_VISIBLE_STATUSES.has(status);
   const showShippingSection = SHIPPING_VISIBLE_STATUSES.has(status);
   const showLalamoveField = LALAMOVE_VISIBLE_STATUSES.has(status);
+  const existingPhotoIds = (existingItem?.qcPhotoIds ?? []).filter((id) => photoIds.includes(id));
 
   const costs = useComputedCosts({
     priceCNY,
@@ -558,6 +560,17 @@ export function ItemForm({ existingItem, onSuccess }: ItemFormProps) {
               <h2 className="font-display font-semibold text-base text-primary">
                 QC Photos
               </h2>
+
+              {existingPhotoIds.length > 0 && (
+                <div className="rounded-lg border border-border-subtle p-3 space-y-2">
+                  <p className="text-xs text-secondary">Existing QC photos</p>
+                  <QcPhotoGallery
+                    photoIds={existingPhotoIds}
+                    onRemovePhoto={handleRemovePhoto}
+                  />
+                </div>
+              )}
+
               <ImageUpload
                 images={photos}
                 onUpload={handleUpload}

--- a/src/components/items/QcPhotoGallery.tsx
+++ b/src/components/items/QcPhotoGallery.tsx
@@ -1,12 +1,13 @@
-import { useState } from "react";
-import { useQuery } from "convex/react";
+import { useMemo, useState } from "react";
+import { useQueries, useQuery, type RequestForQueries } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { Lightbox } from "../ui/Lightbox";
-import { ImageOff } from "lucide-react";
+import { ImageOff, X } from "lucide-react";
 import type { Id } from "../../../convex/_generated/dataModel";
 
 interface QcPhotoGalleryProps {
   photoIds?: Id<"_storage">[];
+  onRemovePhoto?: (photoId: Id<"_storage">) => void;
 }
 
 function PhotoImage({ storageId }: { storageId: Id<"_storage"> }) {
@@ -16,18 +17,51 @@ function PhotoImage({ storageId }: { storageId: Id<"_storage"> }) {
 }
 
 function usePhotoUrls(photoIds: Id<"_storage">[]) {
-  const urls: string[] = [];
-  for (const id of photoIds) {
-    const url = useQuery(api.storage.getUrl, { storageId: id });
-    if (url) urls.push(url);
-  }
-  return urls;
+  const queries = useMemo<RequestForQueries>(() => {
+    const next: RequestForQueries = {};
+    photoIds.forEach((id, index) => {
+      next[String(index)] = {
+        query: api.storage.getUrl,
+        args: { storageId: id },
+      };
+    });
+    return next;
+  }, [photoIds]);
+
+  const results = useQueries(queries);
+
+  return useMemo(
+    () =>
+      photoIds.flatMap((_, index) => {
+        const result = results[String(index)];
+        return typeof result === "string" ? [result] : [];
+      }),
+    [photoIds, results],
+  );
 }
 
-export function QcPhotoGallery({ photoIds }: QcPhotoGalleryProps) {
+export function QcPhotoGallery({ photoIds, onRemovePhoto }: QcPhotoGalleryProps) {
   const [lightboxIndex, setLightboxIndex] = useState(-1);
   const ids = photoIds ?? [];
   const urls = usePhotoUrls(ids);
+  const handleRemoveAtIndex = (index: number) => {
+    const id = ids[index];
+    if (!id || !onRemovePhoto) return;
+    onRemovePhoto(id);
+
+    if (lightboxIndex < 0) return;
+    if (ids.length === 1) {
+      setLightboxIndex(-1);
+      return;
+    }
+    if (index < lightboxIndex) {
+      setLightboxIndex((current) => current - 1);
+      return;
+    }
+    if (index === lightboxIndex && lightboxIndex === ids.length - 1) {
+      setLightboxIndex((current) => Math.max(0, current - 1));
+    }
+  };
 
   if (ids.length === 0) {
     return (
@@ -43,23 +77,54 @@ export function QcPhotoGallery({ photoIds }: QcPhotoGalleryProps) {
       <div className="space-y-3">
         {/* Main photo */}
         <div
-          className="aspect-square rounded-xl overflow-hidden cursor-pointer bg-hover"
+          className="relative aspect-square rounded-xl overflow-hidden cursor-pointer bg-hover"
           onClick={() => setLightboxIndex(0)}
         >
           <PhotoImage storageId={ids[0]} />
+          {onRemovePhoto && (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                handleRemoveAtIndex(0);
+              }}
+              className="absolute top-2 right-2 p-1.5 rounded-full bg-black/70 text-white hover:bg-black/80 transition-colors cursor-pointer"
+              aria-label="Remove QC photo"
+            >
+              <X size={14} />
+            </button>
+          )}
         </div>
 
         {/* Thumbnail strip */}
         {ids.length > 1 && (
           <div className="flex gap-2 overflow-x-auto">
             {ids.map((id, i) => (
-              <button
-                key={id}
-                onClick={() => setLightboxIndex(i)}
-                className="w-16 h-16 rounded-lg overflow-hidden shrink-0 border-2 border-transparent hover:border-accent transition-colors cursor-pointer"
+              <div
+                key={`${id}-${i}`}
+                className="relative w-16 h-16 rounded-lg overflow-hidden shrink-0 border-2 border-transparent hover:border-accent transition-colors"
               >
-                <PhotoImage storageId={id} />
-              </button>
+                <button
+                  type="button"
+                  onClick={() => setLightboxIndex(i)}
+                  className="w-full h-full cursor-pointer"
+                >
+                  <PhotoImage storageId={id} />
+                </button>
+                {onRemovePhoto && (
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleRemoveAtIndex(i);
+                    }}
+                    className="absolute top-1 right-1 p-1 rounded-full bg-black/70 text-white hover:bg-black/80 transition-colors cursor-pointer"
+                    aria-label="Remove QC photo"
+                  >
+                    <X size={12} />
+                  </button>
+                )}
+              </div>
             ))}
           </div>
         )}
@@ -71,6 +136,11 @@ export function QcPhotoGallery({ photoIds }: QcPhotoGalleryProps) {
         open={lightboxIndex >= 0}
         onClose={() => setLightboxIndex(-1)}
         onNavigate={setLightboxIndex}
+        onDeleteCurrent={
+          onRemovePhoto && lightboxIndex >= 0
+            ? () => handleRemoveAtIndex(lightboxIndex)
+            : undefined
+        }
       />
     </>
   );

--- a/src/components/personal/PersonalItemForm.tsx
+++ b/src/components/personal/PersonalItemForm.tsx
@@ -11,6 +11,7 @@ import { Combobox } from "../ui/Combobox";
 import { Button } from "../ui/Button";
 import { Card, CardContent } from "../ui/Card";
 import { ImageUpload } from "../ui/ImageUpload";
+import { QcPhotoGallery } from "../items/QcPhotoGallery";
 import {
   ALL_PERSONAL_STATUSES,
   ALL_QC_STATUSES,
@@ -146,6 +147,7 @@ export function PersonalItemForm({ existingItem, onSuccess }: PersonalItemFormPr
 
   const showQcSection = QC_VISIBLE_STATUSES.has(status);
   const showShippingSection = SHIPPING_VISIBLE_STATUSES.has(status);
+  const existingPhotoIds = (existingItem?.qcPhotoIds ?? []).filter((id) => photoIds.includes(id));
 
   const costs = useComputedCosts({
     priceCNY,
@@ -495,6 +497,17 @@ export function PersonalItemForm({ existingItem, onSuccess }: PersonalItemFormPr
         <Card>
           <CardContent className="space-y-4">
             <h2 className="font-display font-semibold text-base text-primary">QC Photos</h2>
+
+            {existingPhotoIds.length > 0 && (
+              <div className="rounded-lg border border-border-subtle p-3 space-y-2">
+                <p className="text-xs text-secondary">Existing QC photos</p>
+                <QcPhotoGallery
+                  photoIds={existingPhotoIds}
+                  onRemovePhoto={handleRemovePhoto}
+                />
+              </div>
+            )}
+
             <ImageUpload
               images={photos}
               onUpload={handleUpload}

--- a/src/components/ui/Lightbox.tsx
+++ b/src/components/ui/Lightbox.tsx
@@ -8,9 +8,17 @@ interface LightboxProps {
   open: boolean;
   onClose: () => void;
   onNavigate: (index: number) => void;
+  onDeleteCurrent?: () => void;
 }
 
-export function Lightbox({ images, currentIndex, open, onClose, onNavigate }: LightboxProps) {
+export function Lightbox({
+  images,
+  currentIndex,
+  open,
+  onClose,
+  onNavigate,
+  onDeleteCurrent,
+}: LightboxProps) {
   const goNext = useCallback(() => {
     if (currentIndex < images.length - 1) onNavigate(currentIndex + 1);
   }, [currentIndex, images.length, onNavigate]);
@@ -45,6 +53,15 @@ export function Lightbox({ images, currentIndex, open, onClose, onNavigate }: Li
           >
             <X size={24} />
           </button>
+          {onDeleteCurrent && (
+            <button
+              type="button"
+              onClick={onDeleteCurrent}
+              className="absolute top-4 right-16 px-3 py-2 rounded-lg text-sm font-medium text-white/85 bg-white/10 hover:bg-red-500/80 hover:text-white transition-colors cursor-pointer z-10"
+            >
+              Delete photo
+            </button>
+          )}
 
           {currentIndex > 0 && (
             <button

--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -42,6 +42,7 @@ export default function OrderDetail() {
   const [savingProgress, setSavingProgress] = useState(false);
 
   const [qcStatusDraft, setQcStatusDraft] = useState<Doc<"items">["qcStatus"]>("pending_review");
+  const [qcPhotoIdsDraft, setQcPhotoIdsDraft] = useState<Id<"_storage">[]>([]);
   const [newQcUploads, setNewQcUploads] = useState<{ id: Id<"_storage">; url: string }[]>([]);
   const [uploadingQc, setUploadingQc] = useState(false);
 
@@ -127,6 +128,9 @@ export default function OrderDetail() {
           ...current,
           { id: storageId, url: URL.createObjectURL(file) },
         ]);
+        setQcPhotoIdsDraft((current) =>
+          current.includes(storageId) ? current : [...current, storageId]
+        );
       }
     } catch {
       toast.error("Failed to upload QC photos");
@@ -134,7 +138,8 @@ export default function OrderDetail() {
     setUploadingQc(false);
   };
 
-  const handleRemoveNewQcPhoto = (idToRemove: string) => {
+  const handleRemoveQcPhoto = (idToRemove: Id<"_storage">) => {
+    setQcPhotoIdsDraft((current) => current.filter((photoId) => photoId !== idToRemove));
     setNewQcUploads((current) => {
       const photoToRemove = current.find((photo) => photo.id === idToRemove);
       if (photoToRemove) {
@@ -147,6 +152,7 @@ export default function OrderDetail() {
   const openProgressModal = (targetStatus: ProgressiveStatus) => {
     if (targetStatus === "qc_sent") {
       setQcStatusDraft(item.qcStatus === "not_received" ? "pending_review" : item.qcStatus);
+      setQcPhotoIdsDraft(item.qcPhotoIds ?? []);
       clearNewQcUploads();
     }
 
@@ -180,10 +186,24 @@ export default function OrderDetail() {
     void handleStatusChange(newStatus);
   };
 
+  const handleRemoveDetailQcPhoto = async (photoId: Id<"_storage">) => {
+    const currentPhotoIds = item.qcPhotoIds ?? [];
+    if (!currentPhotoIds.includes(photoId)) return;
+    const nextPhotoIds = currentPhotoIds.filter((id) => id !== photoId);
+
+    try {
+      await updateItem({
+        id: item._id,
+        qcPhotoIds: nextPhotoIds,
+      });
+      toast.success("QC photo deleted");
+    } catch {
+      toast.error("Failed to delete QC photo");
+    }
+  };
+
   const handleSaveQcSent = async () => {
-    const existingPhotoIds = item.qcPhotoIds ?? [];
-    const newPhotoIds = newQcUploads.map((photo) => photo.id);
-    const mergedPhotoIds = Array.from(new Set([...existingPhotoIds, ...newPhotoIds]));
+    const mergedPhotoIds = Array.from(new Set(qcPhotoIdsDraft));
 
     if (mergedPhotoIds.length === 0) {
       toast.error("Upload at least one QC photo before setting QC Sent");
@@ -358,7 +378,10 @@ export default function OrderDetail() {
                 </h2>
               </CardHeader>
               <CardContent>
-                <QcPhotoGallery photoIds={item.qcPhotoIds} />
+                <QcPhotoGallery
+                  photoIds={item.qcPhotoIds}
+                  onRemovePhoto={handleRemoveDetailQcPhoto}
+                />
               </CardContent>
             </Card>
 
@@ -537,17 +560,22 @@ export default function OrderDetail() {
         title="QC Sent: Upload Photos"
       >
         <div className="space-y-4">
-          {item.qcPhotoIds && item.qcPhotoIds.length > 0 && (
+          {qcPhotoIdsDraft.length > 0 && (
             <div className="rounded-lg border border-border-subtle p-3">
-              <p className="text-xs text-secondary mb-2">Existing QC Photos</p>
-              <QcPhotoGallery photoIds={item.qcPhotoIds} />
+              <p className="text-xs text-secondary mb-2">
+                QC photo gallery (click X to remove)
+              </p>
+              <QcPhotoGallery
+                photoIds={qcPhotoIdsDraft}
+                onRemovePhoto={handleRemoveQcPhoto}
+              />
             </div>
           )}
 
           <ImageUpload
             images={newQcUploads.map((photo) => ({ id: photo.id, url: photo.url }))}
             onUpload={handleUploadQc}
-            onRemove={handleRemoveNewQcPhoto}
+            onRemove={(id) => handleRemoveQcPhoto(id as Id<"_storage">)}
             uploading={uploadingQc}
           />
 

--- a/src/pages/PersonalDetail.tsx
+++ b/src/pages/PersonalDetail.tsx
@@ -49,6 +49,7 @@ export default function PersonalDetail() {
   const [qcStatusDraft, setQcStatusDraft] = useState<Doc<"personalItems">["qcStatus"]>(
     "pending_review"
   );
+  const [qcPhotoIdsDraft, setQcPhotoIdsDraft] = useState<Id<"_storage">[]>([]);
   const [newQcUploads, setNewQcUploads] = useState<{ id: Id<"_storage">; url: string }[]>(
     []
   );
@@ -128,6 +129,9 @@ export default function PersonalDetail() {
           ...current,
           { id: storageId, url: URL.createObjectURL(file) },
         ]);
+        setQcPhotoIdsDraft((current) =>
+          current.includes(storageId) ? current : [...current, storageId]
+        );
       }
     } catch {
       toast.error("Failed to upload QC photos");
@@ -135,7 +139,8 @@ export default function PersonalDetail() {
     setUploadingQc(false);
   };
 
-  const handleRemoveNewQcPhoto = (idToRemove: string) => {
+  const handleRemoveQcPhoto = (idToRemove: Id<"_storage">) => {
+    setQcPhotoIdsDraft((current) => current.filter((photoId) => photoId !== idToRemove));
     setNewQcUploads((current) => {
       const photoToRemove = current.find((photo) => photo.id === idToRemove);
       if (photoToRemove) {
@@ -148,6 +153,7 @@ export default function PersonalDetail() {
   const openProgressModal = (targetStatus: ProgressiveStatus) => {
     if (targetStatus === "qc_sent") {
       setQcStatusDraft(item.qcStatus === "not_received" ? "pending_review" : item.qcStatus);
+      setQcPhotoIdsDraft(item.qcPhotoIds ?? []);
       clearNewQcUploads();
     }
 
@@ -180,10 +186,24 @@ export default function PersonalDetail() {
     void handleStatusChange(newStatus);
   };
 
+  const handleRemoveDetailQcPhoto = async (photoId: Id<"_storage">) => {
+    const currentPhotoIds = item.qcPhotoIds ?? [];
+    if (!currentPhotoIds.includes(photoId)) return;
+    const nextPhotoIds = currentPhotoIds.filter((id) => id !== photoId);
+
+    try {
+      await updateItem({
+        id: item._id,
+        qcPhotoIds: nextPhotoIds,
+      });
+      toast.success("QC photo deleted");
+    } catch {
+      toast.error("Failed to delete QC photo");
+    }
+  };
+
   const handleSaveQcSent = async () => {
-    const existingPhotoIds = item.qcPhotoIds ?? [];
-    const newPhotoIds = newQcUploads.map((photo) => photo.id);
-    const mergedPhotoIds = Array.from(new Set([...existingPhotoIds, ...newPhotoIds]));
+    const mergedPhotoIds = Array.from(new Set(qcPhotoIdsDraft));
 
     if (mergedPhotoIds.length === 0) {
       toast.error("Upload at least one QC photo before setting QC Sent");
@@ -356,7 +376,10 @@ export default function PersonalDetail() {
                 <h2 className="font-display font-semibold text-sm text-primary">QC Photos</h2>
               </CardHeader>
               <CardContent>
-                <QcPhotoGallery photoIds={item.qcPhotoIds} />
+                <QcPhotoGallery
+                  photoIds={item.qcPhotoIds}
+                  onRemovePhoto={handleRemoveDetailQcPhoto}
+                />
               </CardContent>
             </Card>
           </div>
@@ -453,17 +476,22 @@ export default function PersonalDetail() {
         title="QC Sent: Upload Photos"
       >
         <div className="space-y-4">
-          {item.qcPhotoIds && item.qcPhotoIds.length > 0 && (
+          {qcPhotoIdsDraft.length > 0 && (
             <div className="rounded-lg border border-border-subtle p-3">
-              <p className="text-xs text-secondary mb-2">Existing QC Photos</p>
-              <QcPhotoGallery photoIds={item.qcPhotoIds} />
+              <p className="text-xs text-secondary mb-2">
+                QC photo gallery (click X to remove)
+              </p>
+              <QcPhotoGallery
+                photoIds={qcPhotoIdsDraft}
+                onRemovePhoto={handleRemoveQcPhoto}
+              />
             </div>
           )}
 
           <ImageUpload
             images={newQcUploads.map((photo) => ({ id: photo.id, url: photo.url }))}
             onUpload={handleUploadQc}
-            onRemove={handleRemoveNewQcPhoto}
+            onRemove={(id) => handleRemoveQcPhoto(id as Id<"_storage">)}
             uploading={uploadingQc}
           />
 


### PR DESCRIPTION
## Summary
- show existing QC photos while editing and in QC Sent modal drafts
- add delete controls in QC photo gallery carousel and lightbox (detail page)
- persist deletion by updating qcPhotoIds from detail view actions
- clean up unreferenced QC storage files in Convex on update/remove for items and personalItems

## Validation
- npm run -s build:app
- npx tsc -p convex/tsconfig.json --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to remove QC photos from items and personal items directly in forms
  * QC photo galleries now display with removal controls
  * Added delete button to photo lightbox viewer

* **Bug Fixes**
  * Automatic cleanup of unreferenced QC photos when items are updated or removed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->