### PR TITLE
Fix infinite re-render loop in QcPhotoGallery

### DIFF
--- a/src/components/items/QcPhotoGallery.tsx
+++ b/src/components/items/QcPhotoGallery.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useQueries, useQuery, type RequestForQueries } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { Lightbox } from "../ui/Lightbox";
@@ -42,7 +42,8 @@ function usePhotoUrls(photoIds: Id<"_storage">[]) {
 
 export function QcPhotoGallery({ photoIds, onRemovePhoto }: QcPhotoGalleryProps) {
   const [lightboxIndex, setLightboxIndex] = useState(-1);
-  const ids = photoIds ?? [];
+  const emptyIds = useRef<Id<"_storage">[]>([]).current;
+  const ids = photoIds ?? emptyIds;
   const urls = usePhotoUrls(ids);
   const handleRemoveAtIndex = (index: number) => {
     const id = ids[index];


### PR DESCRIPTION
## Summary
- Stabilize the empty fallback array in `QcPhotoGallery` using `useRef` so that `useQueries` doesn't receive a new object reference every render when `photoIds` is `undefined`
- This fixes a "Too many re-renders" crash when accessing order item detail pages

## Test plan
- [x] Navigate to an order item detail page that has no QC photos — confirm no console errors
- [x] Navigate to an order item detail page with QC photos — confirm gallery renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced photo gallery component stability and performance when handling image data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->