### PR TITLE
Add seller analytics, quote calculator, and settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md
+
+## Project Overview
+JJSMade — a Vite + React + Convex application for managing orders, sellers, and personal shopping.
+
+## Key Architecture Rules
+
+### Convex Schema & Types
+- **Always update `convex/schema.ts` when adding new fields** to any table. The Convex codegen (`convex/_generated/`) derives all TypeScript types from the schema. If you reference a field in frontend code that doesn't exist in the schema, the build will fail with TS2339 errors.
+- After modifying the schema, run `npx convex dev` (or let the dev server pick it up) so that `convex/_generated/api.d.ts` regenerates with the new types.
+- Never manually edit files in `convex/_generated/` — they are auto-generated.
+
+## Tech Stack
+- **Frontend:** React, TypeScript, Vite, Tailwind CSS
+- **Backend:** Convex (schema in `convex/schema.ts`)
+- **Deployment:** Vercel

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type * as auth from "../auth.js";
 import type * as helpers from "../helpers.js";
 import type * as items from "../items.js";
 import type * as personalItems from "../personalItems.js";
+import type * as qcPhotoCleanup from "../qcPhotoCleanup.js";
 import type * as sellers from "../sellers.js";
 import type * as settings from "../settings.js";
 import type * as storage from "../storage.js";
@@ -29,6 +30,7 @@ declare const fullApi: ApiFromModules<{
   helpers: typeof helpers;
   items: typeof items;
   personalItems: typeof personalItems;
+  qcPhotoCleanup: typeof qcPhotoCleanup;
   sellers: typeof sellers;
   settings: typeof settings;
   storage: typeof storage;

--- a/convex/analytics.ts
+++ b/convex/analytics.ts
@@ -1,5 +1,18 @@
 import { query } from "./_generated/server";
 
+const REALIZED_SALE_STATUSES = new Set(["delivered_to_customer", "sold"]);
+const NON_PIPELINE_STATUSES = new Set([
+  "delivered_to_customer",
+  "sold",
+  "refunded",
+  "cancelled",
+  "returned",
+]);
+
+function isRealizedSale(status: string) {
+  return REALIZED_SALE_STATUSES.has(status);
+}
+
 export const getDashboardStats = query({
   args: {},
   handler: async (ctx) => {
@@ -7,13 +20,11 @@ export const getDashboardStats = query({
     const now = new Date();
     const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1).getTime();
 
-    const soldItems = items.filter((i) => i.status === "sold");
+    const soldItems = items.filter((i) => isRealizedSale(i.status));
     const soldThisMonth = soldItems.filter(
       (i) => i.soldDate && i.soldDate >= startOfMonth
     );
-    const inPipeline = items.filter(
-      (i) => i.status !== "sold" && i.status !== "cancelled" && i.status !== "returned"
-    );
+    const inPipeline = items.filter((i) => !NON_PIPELINE_STATUSES.has(i.status));
 
     const revenueThisMonth = soldThisMonth.reduce(
       (sum, i) => sum + (i.sellingPrice ?? 0),
@@ -41,7 +52,7 @@ export const getMonthlyProfitData = query({
   args: {},
   handler: async (ctx) => {
     const items = await ctx.db.query("items").collect();
-    const soldItems = items.filter((i) => i.status === "sold" && i.soldDate);
+    const soldItems = items.filter((i) => isRealizedSale(i.status) && i.soldDate);
 
     const monthly: Record<string, { revenue: number; cost: number; profit: number; count: number }> = {};
 
@@ -68,7 +79,7 @@ export const getProfitByCategory = query({
   args: {},
   handler: async (ctx) => {
     const items = await ctx.db.query("items").collect();
-    const soldItems = items.filter((i) => i.status === "sold");
+    const soldItems = items.filter((i) => isRealizedSale(i.status));
 
     const byCategory: Record<string, { profit: number; count: number; revenue: number }> = {};
 
@@ -90,7 +101,7 @@ export const getProfitBySeller = query({
   args: {},
   handler: async (ctx) => {
     const items = await ctx.db.query("items").collect();
-    const soldItems = items.filter((i) => i.status === "sold");
+    const soldItems = items.filter((i) => isRealizedSale(i.status));
 
     const bySeller: Record<string, { profit: number; count: number; revenue: number }> = {};
 
@@ -111,7 +122,7 @@ export const getCostBreakdown = query({
   args: {},
   handler: async (ctx) => {
     const items = await ctx.db.query("items").collect();
-    const soldItems = items.filter((i) => i.status === "sold");
+    const soldItems = items.filter((i) => isRealizedSale(i.status));
 
     if (soldItems.length === 0) {
       return {
@@ -160,7 +171,7 @@ export const getTopBatches = query({
   args: {},
   handler: async (ctx) => {
     const items = await ctx.db.query("items").collect();
-    const soldItems = items.filter((i) => i.status === "sold" && i.batch);
+    const soldItems = items.filter((i) => isRealizedSale(i.status) && i.batch);
 
     const byBatch: Record<string, { profit: number; count: number }> = {};
 
@@ -182,7 +193,7 @@ export const getTopCustomers = query({
   args: {},
   handler: async (ctx) => {
     const items = await ctx.db.query("items").collect();
-    const soldItems = items.filter((i) => i.status === "sold" && i.customerName);
+    const soldItems = items.filter((i) => isRealizedSale(i.status) && i.customerName);
 
     const byCustomer: Record<string, { totalSpent: number; count: number }> = {};
 
@@ -204,7 +215,7 @@ export const getProfitDistribution = query({
   args: {},
   handler: async (ctx) => {
     const items = await ctx.db.query("items").collect();
-    const soldItems = items.filter((i) => i.status === "sold" && i.profit != null);
+    const soldItems = items.filter((i) => isRealizedSale(i.status) && i.profit != null);
 
     const buckets: Record<string, number> = {};
     const bucketSize = 100;
@@ -231,7 +242,7 @@ export const getCumulativeProfitData = query({
   handler: async (ctx) => {
     const items = await ctx.db.query("items").collect();
     const soldItems = items
-      .filter((i) => i.status === "sold" && i.soldDate && i.profit != null)
+      .filter((i) => isRealizedSale(i.status) && i.soldDate && i.profit != null)
       .sort((a, b) => a.soldDate! - b.soldDate!);
 
     let cumulative = 0;
@@ -250,7 +261,7 @@ export const getItemsSoldByMonth = query({
   args: {},
   handler: async (ctx) => {
     const items = await ctx.db.query("items").collect();
-    const soldItems = items.filter((i) => i.status === "sold" && i.soldDate);
+    const soldItems = items.filter((i) => isRealizedSale(i.status) && i.soldDate);
 
     const monthly: Record<string, number> = {};
 
@@ -270,7 +281,7 @@ export const getAllTimeStats = query({
   args: {},
   handler: async (ctx) => {
     const items = await ctx.db.query("items").collect();
-    const soldItems = items.filter((i) => i.status === "sold");
+    const soldItems = items.filter((i) => isRealizedSale(i.status));
 
     const totalRevenue = soldItems.reduce((sum, i) => sum + (i.sellingPrice ?? 0), 0);
     const totalProfit = soldItems.reduce((sum, i) => sum + (i.profit ?? 0), 0);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -115,6 +115,9 @@ export default defineSchema({
     defaultForwarderRate: v.number(),
     defaultMarkupMin: v.number(),
     defaultMarkupMax: v.number(),
+    calculatorMarkupShoes: v.optional(v.number()),
+    calculatorMarkupClothes: v.optional(v.number()),
+    calculatorMarkupWatchesAccessories: v.optional(v.number()),
     updatedAt: v.number(),
   }),
 

--- a/convex/sellers.ts
+++ b/convex/sellers.ts
@@ -1,6 +1,8 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 
+const REALIZED_SALE_STATUSES = new Set(["delivered_to_customer", "sold"]);
+
 export const create = mutation({
   args: {
     name: v.string(),
@@ -58,7 +60,9 @@ export const list = query({
 
     return filtered.map((seller) => {
       const sellerItems = items.filter((i) => i.seller === seller.name);
-      const soldItems = sellerItems.filter((i) => i.status === "sold");
+      const soldItems = sellerItems.filter((i) =>
+        REALIZED_SALE_STATUSES.has(i.status)
+      );
       const totalProfit = soldItems.reduce((sum, i) => sum + (i.profit ?? 0), 0);
       const avgProfit = soldItems.length > 0 ? totalProfit / soldItems.length : 0;
 

--- a/convex/settings.ts
+++ b/convex/settings.ts
@@ -13,7 +13,22 @@ export const initialize = mutation({
   args: {},
   handler: async (ctx) => {
     const existing = await ctx.db.query("settings").first();
-    if (existing) return existing._id;
+    if (existing) {
+      // Backfill calculator markup fields if missing
+      if (
+        existing.calculatorMarkupShoes === undefined ||
+        existing.calculatorMarkupClothes === undefined ||
+        existing.calculatorMarkupWatchesAccessories === undefined
+      ) {
+        await ctx.db.patch(existing._id, {
+          calculatorMarkupShoes: existing.calculatorMarkupShoes ?? 850,
+          calculatorMarkupClothes: existing.calculatorMarkupClothes ?? 750,
+          calculatorMarkupWatchesAccessories: existing.calculatorMarkupWatchesAccessories ?? 850,
+          updatedAt: Date.now(),
+        });
+      }
+      return existing._id;
+    }
 
     const id = await ctx.db.insert("settings", {
       cnyToPhpRate: 7.8,
@@ -21,6 +36,9 @@ export const initialize = mutation({
       defaultForwarderRate: 480,
       defaultMarkupMin: 700,
       defaultMarkupMax: 850,
+      calculatorMarkupShoes: 850,
+      calculatorMarkupClothes: 750,
+      calculatorMarkupWatchesAccessories: 850,
       updatedAt: Date.now(),
     });
     return id;
@@ -34,6 +52,9 @@ export const update = mutation({
     defaultForwarderRate: v.optional(v.number()),
     defaultMarkupMin: v.optional(v.number()),
     defaultMarkupMax: v.optional(v.number()),
+    calculatorMarkupShoes: v.optional(v.number()),
+    calculatorMarkupClothes: v.optional(v.number()),
+    calculatorMarkupWatchesAccessories: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const settings = await ctx.db.query("settings").first();
@@ -47,6 +68,9 @@ export const update = mutation({
     if (args.defaultForwarderRate !== undefined) updates.defaultForwarderRate = args.defaultForwarderRate;
     if (args.defaultMarkupMin !== undefined) updates.defaultMarkupMin = args.defaultMarkupMin;
     if (args.defaultMarkupMax !== undefined) updates.defaultMarkupMax = args.defaultMarkupMax;
+    if (args.calculatorMarkupShoes !== undefined) updates.calculatorMarkupShoes = args.calculatorMarkupShoes;
+    if (args.calculatorMarkupClothes !== undefined) updates.calculatorMarkupClothes = args.calculatorMarkupClothes;
+    if (args.calculatorMarkupWatchesAccessories !== undefined) updates.calculatorMarkupWatchesAccessories = args.calculatorMarkupWatchesAccessories;
 
     await ctx.db.patch(settings._id, updates);
   },

--- a/src/components/items/ItemCard.tsx
+++ b/src/components/items/ItemCard.tsx
@@ -36,7 +36,7 @@ export function ItemCard({ item }: ItemCardProps) {
         </span>
       </div>
 
-      {item.status === "sold" && (
+      {(item.status === "delivered_to_customer" || item.status === "sold") && (
         <div className="flex items-center justify-between pt-2 border-t border-border-subtle">
           <span className="text-xs text-secondary">Profit</span>
           <ProfitDisplay profit={item.profit} />

--- a/src/components/sellers/SellerCard.tsx
+++ b/src/components/sellers/SellerCard.tsx
@@ -57,7 +57,7 @@ export function SellerCard({ seller, onEdit, onDelete }: SellerCardProps) {
           <p className="font-mono text-sm text-primary">{seller.totalItems}</p>
         </div>
         <div>
-          <p className="text-xs text-tertiary">Sold</p>
+          <p className="text-xs text-tertiary">Delivered</p>
           <p className="font-mono text-sm text-primary">{seller.soldItems}</p>
         </div>
         <div>

--- a/src/components/sellers/SellerStats.tsx
+++ b/src/components/sellers/SellerStats.tsx
@@ -12,7 +12,7 @@ interface SellerStatsProps {
 export function SellerStats({ totalItems, soldItems, totalProfit, avgProfit, totalSpent }: SellerStatsProps) {
   const stats = [
     { label: "Total Items", value: totalItems.toString() },
-    { label: "Items Sold", value: soldItems.toString() },
+    { label: "Items Delivered", value: soldItems.toString() },
     { label: "Total Spent", value: formatPHP(totalSpent) },
     { label: "Total Profit", value: formatPHP(totalProfit), color: "text-success" },
     { label: "Avg Profit", value: formatPHP(avgProfit) },

--- a/src/hooks/useComputedCosts.ts
+++ b/src/hooks/useComputedCosts.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { FORWARDER_BUY_QC_FEE_PHP } from "../lib/constants";
 
 interface ComputedCostsInput {
   priceCNY: number;
@@ -13,8 +14,6 @@ interface ComputedCostsInput {
   lalamoveFee: number;
   sellingPrice: number;
 }
-
-const FORWARDER_BUY_QC_FEE_PHP = 150;
 
 export function useComputedCosts(input: ComputedCostsInput) {
   return useMemo(() => {

--- a/src/hooks/useQuoteCalculator.ts
+++ b/src/hooks/useQuoteCalculator.ts
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+import {
+  DEFAULTS,
+  type ItemCategory,
+} from "../lib/constants";
+import type { AppSettings } from "./useSettings";
+
+type CalculatorMarkupSettings = Pick<
+  AppSettings,
+  | "calculatorMarkupShoes"
+  | "calculatorMarkupClothes"
+  | "calculatorMarkupWatchesAccessories"
+>;
+
+export function getCalculatorMarkupMap(
+  settings: CalculatorMarkupSettings
+): Record<ItemCategory, number> {
+  return {
+    shoes: settings.calculatorMarkupShoes,
+    clothes: settings.calculatorMarkupClothes,
+    watches_accessories: settings.calculatorMarkupWatchesAccessories,
+  };
+}
+
+interface UseQuoteCalculatorInput {
+  category: ItemCategory;
+  totalCost: number;
+  settings: CalculatorMarkupSettings;
+}
+
+export function useQuoteCalculator({
+  category,
+  totalCost,
+  settings,
+}: UseQuoteCalculatorInput) {
+  return useMemo(() => {
+    const markups = getCalculatorMarkupMap(settings);
+    const selectedMarkup =
+      markups[category] ??
+      (category === "clothes"
+        ? DEFAULTS.calculatorMarkupClothes
+        : category === "watches_accessories"
+          ? DEFAULTS.calculatorMarkupWatchesAccessories
+          : DEFAULTS.calculatorMarkupShoes);
+    const customerQuote = round(totalCost + selectedMarkup);
+
+    return {
+      markups,
+      selectedMarkup: round(selectedMarkup),
+      customerQuote,
+    };
+  }, [
+    category,
+    totalCost,
+    settings.calculatorMarkupClothes,
+    settings.calculatorMarkupShoes,
+    settings.calculatorMarkupWatchesAccessories,
+  ]);
+}
+
+function round(value: number) {
+  return Math.round(value * 100) / 100;
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -3,26 +3,68 @@ import { useEffect } from "react";
 import { api } from "../../convex/_generated/api";
 import { DEFAULTS } from "../lib/constants";
 
+export interface AppSettings {
+  cnyToPhpRate: number;
+  forwarderBuyServiceRate: number;
+  defaultForwarderRate: number;
+  defaultMarkupMin: number;
+  defaultMarkupMax: number;
+  calculatorMarkupShoes: number;
+  calculatorMarkupClothes: number;
+  calculatorMarkupWatchesAccessories: number;
+  updatedAt: number;
+}
+
 export function useSettings() {
   const settings = useQuery(api.settings.get);
   const initialize = useMutation(api.settings.initialize);
   const updateSettings = useMutation(api.settings.update);
 
   useEffect(() => {
-    if (settings === null) {
+    if (
+      settings === null ||
+      settings?.calculatorMarkupShoes === undefined ||
+      settings?.calculatorMarkupClothes === undefined ||
+      settings?.calculatorMarkupWatchesAccessories === undefined
+    ) {
       initialize();
     }
   }, [settings, initialize]);
 
+  const fallbackSettings: AppSettings = {
+    cnyToPhpRate: DEFAULTS.exchangeRate,
+    forwarderBuyServiceRate: DEFAULTS.forwarderBuyServiceRate,
+    defaultForwarderRate: DEFAULTS.forwarderRate,
+    defaultMarkupMin: DEFAULTS.markupMin,
+    defaultMarkupMax: DEFAULTS.markupMax,
+    calculatorMarkupShoes: DEFAULTS.calculatorMarkupShoes,
+    calculatorMarkupClothes: DEFAULTS.calculatorMarkupClothes,
+    calculatorMarkupWatchesAccessories:
+      DEFAULTS.calculatorMarkupWatchesAccessories,
+    updatedAt: 0,
+  };
+
   return {
-    settings: settings ?? {
-      cnyToPhpRate: DEFAULTS.exchangeRate,
-      forwarderBuyServiceRate: DEFAULTS.forwarderBuyServiceRate,
-      defaultForwarderRate: DEFAULTS.forwarderRate,
-      defaultMarkupMin: DEFAULTS.markupMin,
-      defaultMarkupMax: DEFAULTS.markupMax,
-      updatedAt: 0,
-    },
+    settings: settings
+      ? {
+          cnyToPhpRate: settings.cnyToPhpRate,
+          forwarderBuyServiceRate:
+            settings.forwarderBuyServiceRate ??
+            DEFAULTS.forwarderBuyServiceRate,
+          defaultForwarderRate: settings.defaultForwarderRate,
+          defaultMarkupMin: settings.defaultMarkupMin,
+          defaultMarkupMax: settings.defaultMarkupMax,
+          calculatorMarkupShoes:
+            settings.calculatorMarkupShoes ?? DEFAULTS.calculatorMarkupShoes,
+          calculatorMarkupClothes:
+            settings.calculatorMarkupClothes ??
+            DEFAULTS.calculatorMarkupClothes,
+          calculatorMarkupWatchesAccessories:
+            settings.calculatorMarkupWatchesAccessories ??
+            DEFAULTS.calculatorMarkupWatchesAccessories,
+          updatedAt: settings.updatedAt,
+        }
+      : fallbackSettings,
     isLoading: settings === undefined,
     updateSettings,
   };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -50,7 +50,13 @@ export const DEFAULTS = {
   forwarderRate: 480,
   markupMin: 700,
   markupMax: 850,
+  calculatorMarkupShoes: 850,
+  calculatorMarkupClothes: 750,
+  calculatorMarkupWatchesAccessories: 850,
 } as const;
+
+export const FORWARDER_BUY_DEFAULT_COMMISSION_PERCENT = 10;
+export const FORWARDER_BUY_QC_FEE_PHP = 150;
 
 export const ALL_STATUSES = Object.keys(STATUS_CONFIG) as ItemStatus[];
 export const ALL_QC_STATUSES = Object.keys(QC_STATUS_CONFIG) as QcStatus[];

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -34,7 +34,7 @@ export default function Dashboard() {
           >
             <StatCard label="Total Items" value={stats.totalItems} icon={<Package size={20} />} />
             <StatCard label="In Pipeline" value={stats.inPipeline} icon={<TrendingUp size={20} />} />
-            <StatCard label="Sold This Month" value={stats.soldThisMonth} icon={<ShoppingBag size={20} />} />
+            <StatCard label="Delivered This Month" value={stats.soldThisMonth} icon={<ShoppingBag size={20} />} />
             <StatCard label="Revenue (Month)" value={stats.revenueThisMonth} format={formatPHP} icon={<DollarSign size={20} />} />
             <StatCard label="Profit (Month)" value={stats.profitThisMonth} format={formatPHP} icon={<BarChart3 size={20} />} />
             <StatCard label="Avg Profit" value={stats.avgProfitThisMonth} format={formatPHP} icon={<Target size={20} />} />

--- a/src/pages/SellerDetail.tsx
+++ b/src/pages/SellerDetail.tsx
@@ -38,7 +38,9 @@ export default function SellerDetail() {
     );
   }
 
-  const soldItems = (items ?? []).filter((i) => i.status === "sold");
+  const soldItems = (items ?? []).filter(
+    (i) => i.status === "delivered_to_customer" || i.status === "sold"
+  );
   const totalProfit = soldItems.reduce((sum, i) => sum + (i.profit ?? 0), 0);
   const avgProfit = soldItems.length > 0 ? totalProfit / soldItems.length : 0;
   const totalSpent = (items ?? []).reduce((sum, i) => sum + (i.pricePHP ?? 0), 0);


### PR DESCRIPTION
## Summary
- Extend seller analytics with updated queries and seller stats
- Add `useQuoteCalculator` hook for quote calculations
- Enhance settings and computed costs hooks
- Refine seller/item card components and dashboard/detail pages

## Test plan
- [x] Verify seller analytics display correctly on dashboard and seller detail pages
- [x] Test quote calculator functionality
- [x] Confirm settings changes persist and computed costs update accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added category-specific markup calculations for quotes (shoes, clothes, watches/accessories).

* **Bug Fixes**
  * Profit information now displays for items with "delivered" status in addition to "sold" status.
  * Extended realized sale calculations to include delivered items.

* **UI Updates**
  * Updated labels: "Sold" → "Delivered", "Items Sold" → "Items Delivered", "Sold This Month" → "Delivered This Month" for clarity.

* **Refactoring**
  * Centralized fee and constant management for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->