### PR TITLE
Hide exchange rate for forwarder buy items

### DIFF
--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -427,11 +427,13 @@ export default function OrderDetail() {
                   Pricing
                 </h3>
                 <InfoRow label="Price (CNY)" value={formatCNY(item.priceCNY)} mono />
-                <InfoRow
-                  label="Exchange Rate"
-                  value={`PHP${item.exchangeRateUsed.toFixed(2)}/CNY1`}
-                  mono
-                />
+                {!item.isForwarderBuy && (
+                  <InfoRow
+                    label="Exchange Rate"
+                    value={`PHP${item.exchangeRateUsed.toFixed(2)}/CNY1`}
+                    mono
+                  />
+                )}
                 <InfoRow label="Price (PHP)" value={formatPHP(item.pricePHP)} mono />
                 {item.localShippingPHP != null && item.localShippingPHP > 0 && (
                   <InfoRow

--- a/src/pages/PersonalDetail.tsx
+++ b/src/pages/PersonalDetail.tsx
@@ -400,11 +400,13 @@ export default function PersonalDetail() {
               <CardContent className="space-y-3">
                 <h3 className="text-xs font-medium text-secondary uppercase tracking-wider">Pricing</h3>
                 <InfoRow label="Price (CNY)" value={formatCNY(item.priceCNY)} mono />
-                <InfoRow
-                  label="Exchange Rate"
-                  value={`PHP${item.exchangeRateUsed.toFixed(2)}/CNY1`}
-                  mono
-                />
+                {!item.isForwarderBuy && (
+                  <InfoRow
+                    label="Exchange Rate"
+                    value={`PHP${item.exchangeRateUsed.toFixed(2)}/CNY1`}
+                    mono
+                  />
+                )}
                 <InfoRow label="Price (PHP)" value={formatPHP(item.pricePHP)} mono />
                 {item.localShippingPHP != null && item.localShippingPHP > 0 && (
                   <InfoRow label="Local Shipping" value={formatPHP(item.localShippingPHP)} mono />


### PR DESCRIPTION
## Summary
- Hide the personal `PHP/CNY` exchange rate row in the Pricing section of order and personal item detail pages when `isForwarderBuy` is true
- The forwarder's service rate (which is the actual rate used for price conversion) is already shown in the forwarder buy section below

## Test plan
- [ ] Open an order detail that uses forwarder buy — verify the personal exchange rate row is hidden
- [ ] Open a personal item detail that uses forwarder buy — same behavior
- [ ] Open a regular (non-forwarder) order — verify the exchange rate row still shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Exchange rate information is now selectively displayed in pricing sections based on transaction type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->