### PR TITLE
Fix StatCard text overflow and Modal scroll behavior

### DIFF
--- a/src/components/dashboard/StatCard.tsx
+++ b/src/components/dashboard/StatCard.tsx
@@ -40,13 +40,13 @@ export function StatCard({ label, value, format, icon, trend }: StatCardProps) {
     >
       <Card className="p-4 relative overflow-hidden">
         <div className="absolute top-0 right-0 w-24 h-24 bg-accent/5 rounded-full -translate-y-1/2 translate-x-1/2" />
-        <div className="flex items-start justify-between relative">
-          <div>
-            <p className="text-xs text-secondary font-medium mb-1">{label}</p>
-            <p className="font-mono text-2xl font-bold text-primary">{formatted}</p>
-            {trend && <p className="text-xs text-success mt-1">{trend}</p>}
+        <div className="flex items-start justify-between gap-2 relative">
+          <div className="min-w-0 flex-1">
+            <p className="text-xs text-secondary font-medium mb-1 truncate">{label}</p>
+            <p className="font-mono text-xl sm:text-2xl font-bold text-primary truncate">{formatted}</p>
+            {trend && <p className="text-xs text-success mt-1 truncate">{trend}</p>}
           </div>
-          <div className="w-10 h-10 rounded-xl bg-accent-muted flex items-center justify-center text-accent">
+          <div className="w-10 h-10 rounded-xl bg-accent-muted flex items-center justify-center text-accent shrink-0">
             {icon}
           </div>
         </div>

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -41,7 +41,7 @@ export function Modal({ open, onClose, title, children, className }: ModalProps)
             exit={{ opacity: 0, scale: 0.95, y: 10 }}
             transition={{ duration: 0.15 }}
             className={cn(
-              "relative w-full max-w-lg rounded-xl border border-border-default bg-elevated shadow-2xl",
+              "relative w-full max-w-lg max-h-[90vh] flex flex-col rounded-xl border border-border-default bg-elevated shadow-2xl",
               className
             )}
           >
@@ -58,7 +58,7 @@ export function Modal({ open, onClose, title, children, className }: ModalProps)
                 </button>
               </div>
             )}
-            <div className="p-5">{children}</div>
+            <div className="p-5 overflow-y-auto">{children}</div>
           </motion.div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Add truncation and responsive sizing to StatCard to prevent text overflow on small screens
- Add `max-height: 90vh` and `overflow-y: auto` to Modal for long content that exceeds viewport

## Test plan
- [ ] Verify StatCard labels/values truncate properly on narrow screens (mobile, 2-col grid)
- [ ] Open a Modal with long content and confirm it scrolls instead of overflowing the viewport
- [ ] Check all pages using StatCard (Dashboard, Analytics) at various breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)