### PR TITLE
Fix settings page cards horizontal alignment

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -60,7 +60,7 @@ export default function Settings() {
   if (isLoading) {
     return (
       <PageContainer>
-        <div className="max-w-2xl space-y-8">
+        <div className="max-w-2xl mx-auto space-y-8">
           <Skeleton className="h-48" />
           <Skeleton className="h-32" />
           <Skeleton className="h-32" />
@@ -71,7 +71,7 @@ export default function Settings() {
 
   return (
     <PageContainer>
-      <div className="max-w-2xl space-y-8">
+      <div className="max-w-2xl mx-auto space-y-8">
         <Card>
           <CardContent className="space-y-4">
             <h2 className="font-display font-semibold text-base text-primary">


### PR DESCRIPTION
## Summary
- Add `mx-auto` to center the settings cards container within the page
- Applies to both loading skeleton and main content states

## Test plan
- [ ] Open the Settings page
- [ ] Verify the cards are horizontally centered on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Settings page layout for improved content centering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->